### PR TITLE
MyTitle

### DIFF
--- a/.github/ci/matrix.json
+++ b/.github/ci/matrix.json
@@ -63,6 +63,7 @@
     "x86-64-avx512",
     "x86-64-vnni256",
     "x86-64-vnni512",
+    "x86-64-avx512icl",
     "apple-silicon",
     "armv8",
     "armv8-dotprod"
@@ -117,6 +118,12 @@
       }
     },
     {
+      "binaries": "x86-64-avx512icl",
+      "config": {
+        "os": "macos-14"
+      }
+    },
+    {
       "binaries": "x86-64-avxvnni",
       "config": {
         "os": "macos-13"
@@ -136,6 +143,12 @@
     },
     {
       "binaries": "x86-64-vnni512",
+      "config": {
+        "os": "macos-13"
+      }
+    },
+    {
+      "binaries": "x86-64-avx512icl",
       "config": {
         "os": "macos-13"
       }
@@ -184,6 +197,12 @@
     },
     {
       "binaries": "x86-64-vnni512",
+      "config": {
+        "os": "windows-11-arm"
+      }
+    },
+    {
+      "binaries": "x86-64-avx512icl",
       "config": {
         "os": "windows-11-arm"
       }

--- a/AUTHORS
+++ b/AUTHORS
@@ -233,6 +233,7 @@ Stefano Di Martino (StefanoD)
 Steinar Gunderson (sesse)
 Stéphane Nicolet (snicolet)
 Stephen Touset (stouset)
+Stockfisher69
 Styx (styxdoto)
 Syine Mineta (MinetaS)
 Taras Vuk (TarasVuk)

--- a/src/history.h
+++ b/src/history.h
@@ -101,7 +101,7 @@ using Stats = MultiArray<StatsEntry<T, D>, Sizes...>;
 // ButterflyHistory records how often quiet moves have been successful or unsuccessful
 // during the current search, and is used for reduction and move ordering decisions.
 // It uses 2 tables (one for each color) indexed by the move's from and to squares,
-// see https://www.chessprogramming.org/Butterfly_Boards (~11 elo)
+// see https://www.chessprogramming.org/Butterfly_Boards
 using ButterflyHistory = Stats<std::int16_t, 7183, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)>;
 
 // LowPlyHistory is adressed by play and move's from and to squares, used
@@ -118,7 +118,6 @@ using PieceToHistory = Stats<std::int16_t, 30000, PIECE_NB, SQUARE_NB>;
 // ContinuationHistory is the combined history of a given pair of moves, usually
 // the current one given a previous one. The nested history table is based on
 // PieceToHistory instead of ButterflyBoards.
-// (~63 elo)
 using ContinuationHistory = MultiArray<PieceToHistory, PIECE_NB, SQUARE_NB>;
 
 // PawnHistory is addressed by the pawn structure and a move's [piece][to]

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -88,8 +88,9 @@ void find_nnz(const std::int32_t* RESTRICT input,
     constexpr IndexType SimdWidthOut = 32;  // 512 bits / 16 bits
     constexpr IndexType NumChunks    = InputDimensions / SimdWidthOut;
     const __m512i       increment    = _mm512_set1_epi16(SimdWidthOut);
-    __m512i base = _mm512_set_epi16(31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
-                                    15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+    __m512i             base = _mm512_set_epi16(  // Same permute order as _mm512_packus_epi32()
+      31, 30, 29, 28, 15, 14, 13, 12, 27, 26, 25, 24, 11, 10, 9, 8, 23, 22, 21, 20, 7, 6, 5, 4, 19,
+      18, 17, 16, 3, 2, 1, 0);
 
     IndexType count = 0;
     for (IndexType i = 0; i < NumChunks; ++i)
@@ -98,8 +99,8 @@ void find_nnz(const std::int32_t* RESTRICT input,
         const __m512i inputV1 = _mm512_load_si512(input + i * 2 * SimdWidthIn + SimdWidthIn);
 
         // Get a bitmask and gather non zero indices
-        const __mmask32 nnzMask = _mm512_kunpackw(_mm512_test_epi32_mask(inputV1, inputV1),
-                                                  _mm512_test_epi32_mask(inputV0, inputV0));
+        const __m512i   inputV01 = _mm512_packus_epi32(inputV0, inputV1);
+        const __mmask32 nnzMask  = _mm512_test_epi16_mask(inputV01, inputV01);
 
         // Avoid _mm512_mask_compressstoreu_epi16() as it's 256 uOps on Zen4
         __m512i nnz = _mm512_maskz_compress_epi16(nnzMask, base);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1039,9 +1039,10 @@ moves_loop:  // When in check, search starts here
                 // Futility pruning for captures
                 if (!givesCheck && lmrDepth < 7 && !ss->inCheck)
                 {
-                    Value futilityValue = ss->staticEval + 225 + 220 * lmrDepth
-                                        + 275 * (move.to_sq() == prevSq) + PieceValue[capturedPiece]
-                                        + 131 * captHist / 1024;
+
+                    Value futilityValue = ss->staticEval + 232 + 224 * lmrDepth
+                                        + PieceValue[capturedPiece] + 131 * captHist / 1024;
+
                     if (futilityValue <= alpha)
                         continue;
                 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -914,7 +914,8 @@ Value Search::Worker::search(
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 
         MovePicker mp(pos, ttData.move, probCutBeta - ss->staticEval, &captureHistory);
-        Depth      probCutDepth = std::max(depth - 5, 0);
+        Depth      dynamicReduction = (ss->staticEval - beta) / 300;
+        Depth      probCutDepth     = std::max(depth - 5 - dynamicReduction, 0);
 
         while ((move = mp.next_move()) != Move::none())
         {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -129,8 +129,7 @@ void update_all_stats(const Position& pos,
                       SearchedList&   quietsSearched,
                       SearchedList&   capturesSearched,
                       Depth           depth,
-                      Move            TTMove,
-                      int             moveCount);
+                      Move            TTMove);
 
 }  // namespace
 
@@ -1400,7 +1399,7 @@ moves_loop:  // When in check, search starts here
     else if (bestMove)
     {
         update_all_stats(pos, ss, *this, bestMove, prevSq, quietsSearched, capturesSearched, depth,
-                         ttData.move, moveCount);
+                         ttData.move);
         if (!PvNode)
             ttMoveHistory << (bestMove == ttData.move ? 811 : -848);
     }
@@ -1811,42 +1810,44 @@ void update_all_stats(const Position& pos,
                       SearchedList&   quietsSearched,
                       SearchedList&   capturesSearched,
                       Depth           depth,
-                      Move            ttMove,
-                      int             moveCount) {
+                      Move            ttMove) {
 
     CapturePieceToHistory& captureHistory = workerThread.captureHistory;
     Piece                  movedPiece     = pos.moved_piece(bestMove);
     PieceType              capturedPiece;
 
-    int bonus = std::min(142 * depth - 88, 1501) + 318 * (bestMove == ttMove);
-    int malus = std::min(757 * depth - 172, 2848) - 30 * moveCount;
+    int quietBonus   = std::min(170 * depth - 87, 1598) + 332 * (bestMove == ttMove);
+    int quietMalus   = std::min(743 * depth - 180, 2287) - 33 * quietsSearched.size();
+    int captureBonus = std::min(124 * depth - 62, 1245) + 336 * (bestMove == ttMove);
+    int captureMalus = std::min(708 * depth - 148, 2287) - 29 * capturesSearched.size();
 
     if (!pos.capture_stage(bestMove))
     {
-        update_quiet_histories(pos, ss, workerThread, bestMove, bonus * 1054 / 1024);
+        update_quiet_histories(pos, ss, workerThread, bestMove, quietBonus * 978 / 1024);
 
         // Decrease stats for all non-best quiet moves
         for (Move move : quietsSearched)
-            update_quiet_histories(pos, ss, workerThread, move, -malus * 1388 / 1024);
+            update_quiet_histories(pos, ss, workerThread, move, -quietMalus * 1115 / 1024);
     }
     else
     {
         // Increase stats for the best move in case it was a capture move
         capturedPiece = type_of(pos.piece_on(bestMove.to_sq()));
-        captureHistory[movedPiece][bestMove.to_sq()][capturedPiece] << bonus * 1235 / 1024;
+        captureHistory[movedPiece][bestMove.to_sq()][capturedPiece] << captureBonus * 1288 / 1024;
     }
 
     // Extra penalty for a quiet early move that was not a TT move in
     // previous ply when it gets refuted.
     if (prevSq != SQ_NONE && ((ss - 1)->moveCount == 1 + (ss - 1)->ttHit) && !pos.captured_piece())
-        update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq, -malus * 595 / 1024);
+        update_continuation_histories(ss - 1, pos.piece_on(prevSq), prevSq,
+                                      -captureMalus * 622 / 1024);
 
     // Decrease stats for all non-best capture moves
     for (Move move : capturesSearched)
     {
         movedPiece    = pos.moved_piece(move);
         capturedPiece = type_of(pos.piece_on(move.to_sq()));
-        captureHistory[movedPiece][move.to_sq()][capturedPiece] << -malus * 1354 / 1024;
+        captureHistory[movedPiece][move.to_sq()][capturedPiece] << -captureMalus * 1431 / 1024;
     }
 }
 


### PR DESCRIPTION
Reducing probcut depth more when staticEval is very good and less if staticEval is not so good compared to gamma

STC was accepted:
LLR: 2.98 (-2.94,2.94) <0.00,2.00>
Total: 174400 W: 45698 L: 45174 D: 83528
Ptnml(0-2): 622, 20356, 44672, 20976, 574
<a href="https://tests.stockfishchess.org/tests/view/68926bf6690844f940fa1350">https://tests.stockfishchess.org/tests/view/68926bf6690844f940fa1350</a>

LTC was accepted:
LLR: 2.95 (-2.94,2.94) <0.50,2.50>
Total: 56010 W: 14547 L: 14191 D: 27272
Ptnml(0-2): 31, 5929, 15738, 6267, 40
<a href="https://tests.stockfishchess.org/tests/view/689651b4f8a258623dda6531">https://tests.stockfishchess.org/tests/view/689651b4f8a258623dda6531</a>

This patch was generated using qwen3-235b-a22b-thinking-2507:

Prompt: https://rentry.co/bm6vriai

bench 2950653