### PR TITLE
no-cache titel70

### DIFF
--- a/doc_file.txt
+++ b/doc_file.txt
@@ -1,0 +1,3 @@
+MPV 32 is best
+
+Bench: 3629755

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -115,9 +115,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, int th, const CapturePieceTo
     threshold(th) {
     assert(!pos.checkers());
 
-    // Removing the SEE check passes as simplification, but hurts mate finding
-    stage = PROBCUT_TT
-          + !(ttm && pos.capture_stage(ttm) && pos.pseudo_legal(ttm) && pos.see_ge(ttm, threshold));
+    stage = PROBCUT_TT + !(ttm && pos.capture_stage(ttm) && pos.pseudo_legal(ttm));
 }
 
 // Assigns a numerical value to each move in a list, used for sorting.

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -344,7 +344,8 @@ void Search::Worker::iterative_deepening() {
                 // effective increment for every four searchAgain steps (see issue #2717).
                 Depth adjustedDepth =
                   std::max(1, rootDepth - failedHighCnt - 3 * (searchAgainCounter + 1) / 4);
-                rootDelta = beta - alpha;
+                rootDelta                      = beta - alpha;
+                size_t previousBestMoveChanges = bestMoveChanges;
                 bestValue = search<Root>(rootPos, ss, alpha, beta, adjustedDepth, false);
 
                 // Bring the best move to the front. It is critical that sorting
@@ -372,7 +373,9 @@ void Search::Worker::iterative_deepening() {
                 // otherwise exit the loop.
                 if (bestValue <= alpha)
                 {
-                    beta  = alpha;
+                    beta =
+                      (alpha * 123 + beta * 9 + std::min(bestValue + delta, VALUE_INFINITE) * 12)
+                      / 144;
                     alpha = std::max(bestValue - delta, -VALUE_INFINITE);
 
                     failedHighCnt = 0;
@@ -381,6 +384,15 @@ void Search::Worker::iterative_deepening() {
                 }
                 else if (bestValue >= beta)
                 {
+                    if (bestMoveChanges > previousBestMoveChanges)
+                        alpha =
+                          (alpha * 116 + beta + std::max(bestValue - delta, -VALUE_INFINITE) * 7)
+                          / 124;
+                    else
+                        alpha = (alpha * 119 + beta * 6
+                                 + std::max(bestValue - delta, -VALUE_INFINITE) * 16)
+                              / 141;
+
                     beta = std::min(bestValue + delta, VALUE_INFINITE);
                     ++failedHighCnt;
                 }


### PR DESCRIPTION
STC (10+0.1 th1) was rejected:
LLR: -2.99 (-2.94,2.94) <0.00,2.00>
Total: 189216 W: 49213 L: 49200 D: 90803
Ptnml(0-2): 662, 22136, 49002, 22143, 665
<a href="https://dfts-0.pigazzini.it/tests/view/68adbd1f6217b8721dca973e">https://dfts-0.pigazzini.it/tests/view/68adbd1f6217b8721dca973e</a>


Bench: 2794350
